### PR TITLE
Update deprecated pyproject.toml to latest specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,19 @@ authors = [
 ]
 description = "Python3 AsyncIO Tinkerforge driver"
 readme = "README.md"
-license = { text="GNU General Public License v3 (GPLv3)" }
-requires-python = ">=3.7"
+license = "GPL-3.0-or-later"
+license-files = [
+    "LICENSE",
+]
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
@@ -71,7 +74,7 @@ markers = [
 
 [build-system]
 requires = [
-    "setuptools>=61.0",
+    "setuptools>=77.0",
     "typing-extensions; python_version <'3.11'",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR changes the license to a [SPDX license expression](https://packaging.python.org/en/latest/glossary/#term-License-Expression).